### PR TITLE
Update Dockerfile to fix dependency problems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang_nodejs:v1-ly
+FROM golang:1.8
 
 MAINTAINER LIUYE, BUAA <1601695692@qq.com>
 
@@ -17,14 +17,13 @@ ADD fuzzer_run.sh fuzzer_run.sh
 ADD tester_run.sh tester_run.sh
 ADD geth_run.sh  geth_run.sh
 ADD run.sh  run.sh
+RUN apt-get update && apt install git make gcc musl-dev -y --no-install-recommends apt-utils
 RUN \
   (cd go-ethereum && make geth)                                && \
-  (cd contract_fuzzer && source ./gopath.sh && cd ./src/ContractFuzzer/contractfuzzer && go build -o contract_fuzzer) && \ 
+  (cd contract_fuzzer && . ./gopath.sh && cd ./src/ContractFuzzer/contractfuzzer && go build -o contract_fuzzer) && \ 
   cp contract_fuzzer/src/ContractFuzzer/contractfuzzer/contract_fuzzer /usr/local/bin   && \
   cp go-ethereum/build/bin/geth /usr/local/bin/                && \
-  apk del git  make gcc musl-dev linux-headers                 && \
   rm -rf ./go-ethereum && rm -rf ./contract_fuzzer                 && \ 
   rm -rf /var/cache/apk/*              
 
 CMD ["sh"]
-


### PR DESCRIPTION
The old base image does not exist on Docker Hub and consequently leads to the build failure. I've changed it to the golang official base image. Commands for building the project have also been fixed. 